### PR TITLE
fix: prevent crash in determineDropResult (Fixes #1281)

### DIFF
--- a/packages/dnd-core/src/actions/dragDrop/drop.ts
+++ b/packages/dnd-core/src/actions/dragDrop/drop.ts
@@ -50,7 +50,7 @@ function determineDropResult(
 	monitor: DragDropMonitor,
 ) {
 	const target = registry.getTarget(targetId)
-	let dropResult = target.drop(monitor, targetId)
+	let dropResult = target ? target.drop(monitor, targetId) : undefined
 	verifyDropResultType(dropResult)
 	if (typeof dropResult === 'undefined') {
 		dropResult = index === 0 ? {} : monitor.getDropResult()


### PR DESCRIPTION
When target is undefined, determineDropResult crashes. I was not able to determine why `registry.getTarget` would return undefined. The issues happens sometimes when I am dragging and dropping quickly. Perhaps the drop target is getting unmounted as mentioned in #31.

This small change fixes the issue for me, but I am happy to dig deeper if someone can point me in the right direction regarding what else to look for and where.